### PR TITLE
fix: createOriginHeaders in case where no origin request header is present

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,6 +49,7 @@ export function isAllowedOrigin (origin: ReturnType<typeof getRequestHeaders>['o
 
 export function createOriginHeaders (event: CompatibilityEvent, options: CorsOptions): AccessControlAllowOriginHeader {
   const { origin } = options
+  // Type assertion is needed due to upstream issue: https://github.com/unjs/h3/issues/176
   const requestOriginHeader = getRequestHeader(event, 'Origin') as string | undefined
 
   if (!requestOriginHeader || !origin || origin === '*') {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,8 +58,8 @@ export function createOriginHeaders (event: CompatibilityEvent, options: CorsOpt
     return { 'Access-Control-Allow-Origin': origin, Vary: 'Origin' }
   }
 
-  const requestOriginHeader = getRequestHeader(event, 'Origin') as string
-  const headers = Array.isArray(requestOriginHeader) ? requestOriginHeader.join(',') : requestOriginHeader
+  const requestOriginHeader = getRequestHeader(event, 'Origin') as string | undefined
+  const headers = !requestOriginHeader ? '*' : Array.isArray(requestOriginHeader) ? requestOriginHeader.join(',') : requestOriginHeader
 
   return { 'Access-Control-Allow-Origin': headers, Vary: 'Origin' }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,8 +49,9 @@ export function isAllowedOrigin (origin: ReturnType<typeof getRequestHeaders>['o
 
 export function createOriginHeaders (event: CompatibilityEvent, options: CorsOptions): AccessControlAllowOriginHeader {
   const { origin } = options
+  const requestOriginHeader = getRequestHeader(event, 'Origin') as string | undefined
 
-  if (!origin || origin === '*') {
+  if (!requestOriginHeader || !origin || origin === '*') {
     return { 'Access-Control-Allow-Origin': '*' }
   }
 
@@ -58,8 +59,7 @@ export function createOriginHeaders (event: CompatibilityEvent, options: CorsOpt
     return { 'Access-Control-Allow-Origin': origin, Vary: 'Origin' }
   }
 
-  const requestOriginHeader = getRequestHeader(event, 'Origin') as string | undefined
-  const headers = !requestOriginHeader ? '*' : Array.isArray(requestOriginHeader) ? requestOriginHeader.join(',') : requestOriginHeader
+  const headers = Array.isArray(requestOriginHeader) ? requestOriginHeader.join(',') : requestOriginHeader
 
   return { 'Access-Control-Allow-Origin': headers, Vary: 'Origin' }
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -183,6 +183,18 @@ describe('createOriginHeaders', () => {
     expect(createOriginHeaders(eventMock, options2)).toEqual({ 'Access-Control-Allow-Origin': '*' })
   })
 
+  it('returns an object whose `Access-Control-Allow-Origin` is `"*"` if `origin` header is not defined', () => {
+    const eventMock = {
+      req: {
+        method: 'OPTIONS',
+        headers: {}
+      }
+    } as CompatibilityEvent
+    const options: CorsOptions = {}
+
+    expect(createOriginHeaders(eventMock, options)).toEqual({ 'Access-Control-Allow-Origin': '*' })
+  })
+
   it('returns an object with `Access-Control-Allow-Origin` and `Vary` keys if `origin` option is `"null"`', () => {
     const eventMock = {
       req: {


### PR DESCRIPTION
Should fix #1 