### PR TITLE
chore!: upgrade h3 to v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@vitest/coverage-c8": "^0.25.1",
     "defu": "^6.1.0",
     "eslint": "^8.27.0",
+    "h3": "^1.0.1",
     "standard-version": "^9.5.0",
     "typescript": "^4.8.4",
     "unbuild": "^0.9.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "defu": "^6.1.0",
-    "h3": "^0.8.6"
+    "h3": "^1.0.1"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "^11.0.0",
@@ -36,7 +36,6 @@
     "@vitest/coverage-c8": "^0.25.1",
     "defu": "^6.1.0",
     "eslint": "^8.27.0",
-    "h3": "^0.8.6",
     "standard-version": "^9.5.0",
     "typescript": "^4.8.4",
     "unbuild": "^0.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,15 +12,13 @@ specifiers:
   unbuild: ^0.9.4
   vitest: ^0.25.1
 
-dependencies:
-  h3: 1.0.1
-
 devDependencies:
   '@nuxtjs/eslint-config-typescript': 11.0.0_rmayb2veg2btbq6mbmnyivgasy
   '@types/node': 18.11.0
   '@vitest/coverage-c8': 0.25.1
   defu: 6.1.0
   eslint: 8.27.0
+  h3: 1.0.1
   standard-version: 9.5.0
   typescript: 4.8.4
   unbuild: 0.9.4
@@ -1192,7 +1190,7 @@ packages:
 
   /cookie-es/0.5.0:
     resolution: {integrity: sha512-RyZrFi6PNpBFbIaQjXDlFIhFVqV42QeKSZX1yQIl6ihImq6vcHNGMtqQ/QzY3RMPuYSkvsRwtnt5M9NeYxKt0g==}
-    dev: false
+    dev: true
 
   /core-util-is/1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -1304,7 +1302,7 @@ packages:
 
   /destr/1.2.1:
     resolution: {integrity: sha512-ud8w0qMLlci6iFG7CNgeRr8OcbUWMsbfjtWft1eJ5Luqrz/M8Ebqk/KCzne8rKUlIQWWfLv0wD6QHrqOf4GshA==}
-    dev: false
+    dev: true
 
   /detect-indent/6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -2515,7 +2513,7 @@ packages:
       destr: 1.2.1
       radix3: 1.0.0
       ufo: 1.0.0
-    dev: false
+    dev: true
 
   /handlebars/4.7.7:
     resolution: {integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==}
@@ -3444,7 +3442,7 @@ packages:
 
   /radix3/1.0.0:
     resolution: {integrity: sha512-6n3AEXth91ASapMVKiEh2wrbFJmI+NBilrWE0AbiGgfm0xet0QXC8+a3K19r1UVYjUjctUgB053c3V/J6V0kCQ==}
-    dev: false
+    dev: true
 
   /read-pkg-up/3.0.0:
     resolution: {integrity: sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==}
@@ -3987,7 +3985,7 @@ packages:
 
   /ufo/1.0.0:
     resolution: {integrity: sha512-DRty0ZBNlJ2R59y4mEupJRKLbkLQsc4qtxjpQv78AwEDuBkaUogMc2LkeqW3HddFlw6NwnXYfdThEZOiNgkmmQ==}
-    dev: false
+    dev: true
 
   /uglify-js/3.17.0:
     resolution: {integrity: sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,11 +6,14 @@ specifiers:
   '@vitest/coverage-c8': ^0.25.1
   defu: ^6.1.0
   eslint: ^8.27.0
-  h3: ^0.8.6
+  h3: ^1.0.1
   standard-version: ^9.5.0
   typescript: ^4.8.4
   unbuild: ^0.9.4
   vitest: ^0.25.1
+
+dependencies:
+  h3: 1.0.1
 
 devDependencies:
   '@nuxtjs/eslint-config-typescript': 11.0.0_rmayb2veg2btbq6mbmnyivgasy
@@ -18,7 +21,6 @@ devDependencies:
   '@vitest/coverage-c8': 0.25.1
   defu: 6.1.0
   eslint: 8.27.0
-  h3: 0.8.6
   standard-version: 9.5.0
   typescript: 4.8.4
   unbuild: 0.9.4
@@ -1190,7 +1192,7 @@ packages:
 
   /cookie-es/0.5.0:
     resolution: {integrity: sha512-RyZrFi6PNpBFbIaQjXDlFIhFVqV42QeKSZX1yQIl6ihImq6vcHNGMtqQ/QzY3RMPuYSkvsRwtnt5M9NeYxKt0g==}
-    dev: true
+    dev: false
 
   /core-util-is/1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -1300,9 +1302,9 @@ packages:
     resolution: {integrity: sha512-pOFYRTIhoKujrmbTRhcW5lYQLBXw/dlTwfI8IguF1QCDJOcJzNH1w+YFjxqy6BAuJrClTy6MUE8q+oKJ2FLsIw==}
     dev: true
 
-  /destr/1.2.0:
-    resolution: {integrity: sha512-JG+cG4ZPB1L27sl2C2URg8MIOmIUtTbE5wEx02BpmrTCqg/hXxFKXsYsnODl5PdpqNRaS1KQGUQ56V8jk8XpYQ==}
-    dev: true
+  /destr/1.2.1:
+    resolution: {integrity: sha512-ud8w0qMLlci6iFG7CNgeRr8OcbUWMsbfjtWft1eJ5Luqrz/M8Ebqk/KCzne8rKUlIQWWfLv0wD6QHrqOf4GshA==}
+    dev: false
 
   /detect-indent/6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -2506,14 +2508,14 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
-  /h3/0.8.6:
-    resolution: {integrity: sha512-CSWNOKa3QGo67rFU2PhbFTp0uPJtilNji2Z0pMiSRQt3+OkIW0u3E1WMJqIycLqaTgb9JyFqH/S4mcTyyGtvyQ==}
+  /h3/1.0.1:
+    resolution: {integrity: sha512-gDCGpRvjchZW2JBlTqbJ9IOs+mdkXXuwSQkSye+jubHAv/UhdamKqoQvd4RFgyBNjHSId8Y+b10UdTcPlP/V+w==}
     dependencies:
       cookie-es: 0.5.0
-      destr: 1.2.0
-      radix3: 0.2.1
-      ufo: 0.8.6
-    dev: true
+      destr: 1.2.1
+      radix3: 1.0.0
+      ufo: 1.0.0
+    dev: false
 
   /handlebars/4.7.7:
     resolution: {integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==}
@@ -3440,9 +3442,9 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /radix3/0.2.1:
-    resolution: {integrity: sha512-FnhArTl5Tq7dodiLeSPKrDUyCQuJqEncP8cKdyy399g8F/cz7GH6FmzA3Rkosu2IZMkpswFFwXfb2ERSiL06pg==}
-    dev: true
+  /radix3/1.0.0:
+    resolution: {integrity: sha512-6n3AEXth91ASapMVKiEh2wrbFJmI+NBilrWE0AbiGgfm0xet0QXC8+a3K19r1UVYjUjctUgB053c3V/J6V0kCQ==}
+    dev: false
 
   /read-pkg-up/3.0.0:
     resolution: {integrity: sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==}
@@ -3982,6 +3984,10 @@ packages:
   /ufo/0.8.6:
     resolution: {integrity: sha512-fk6CmUgwKCfX79EzcDQQpSCMxrHstvbLswFChHS0Vump+kFkw7nJBfTZoC1j0bOGoY9I7R3n2DGek5ajbcYnOw==}
     dev: true
+
+  /ufo/1.0.0:
+    resolution: {integrity: sha512-DRty0ZBNlJ2R59y4mEupJRKLbkLQsc4qtxjpQv78AwEDuBkaUogMc2LkeqW3HddFlw6NwnXYfdThEZOiNgkmmQ==}
+    dev: false
 
   /uglify-js/3.17.0:
     resolution: {integrity: sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==}

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -9,9 +9,9 @@ export function defineCorsEventHandler (options: CorsOptions) {
     if (isPreflight(event)) {
       appendCorsPreflightHeaders(event, options)
 
-      event.res.statusCode = statusCode
-      event.res.setHeader('Content-Length', '0')
-      event.res.end()
+      event.node.res.statusCode = statusCode
+      event.node.res.setHeader('Content-Length', '0')
+      event.node.res.end()
     } else {
       appendCorsActualRequestHeaders(event, options)
     }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -45,11 +45,13 @@ describe('resolveCorsOptions', () => {
 describe('isPreflight', () => {
   it('can detect preflight request', () => {
     const eventMock = {
-      req: {
-        method: 'OPTIONS',
-        headers: {
-          origin: 'http://example.com',
-          'access-control-request-method': 'GET'
+      node: {
+        req: {
+          method: 'OPTIONS',
+          headers: {
+            origin: 'http://example.com',
+            'access-control-request-method': 'GET'
+          }
         }
       }
     } as H3Event
@@ -59,11 +61,13 @@ describe('isPreflight', () => {
 
   it('can detect request of non-OPTIONS method)', () => {
     const eventMock = {
-      req: {
-        method: 'GET',
-        headers: {
-          origin: 'http://example.com',
-          'access-control-request-method': 'GET'
+      node: {
+        req: {
+          method: 'GET',
+          headers: {
+            origin: 'http://example.com',
+            'access-control-request-method': 'GET'
+          }
         }
       }
     } as H3Event
@@ -73,10 +77,12 @@ describe('isPreflight', () => {
 
   it('can detect request without Origin header', () => {
     const eventMock = {
-      req: {
-        method: 'OPTIONS',
-        headers: {
-          'access-control-request-method': 'GET'
+      node: {
+        req: {
+          method: 'OPTIONS',
+          headers: {
+            'access-control-request-method': 'GET'
+          }
         }
       }
     } as H3Event
@@ -86,10 +92,12 @@ describe('isPreflight', () => {
 
   it('can detect request without AccessControlRequestMethod header', () => {
     const eventMock = {
-      req: {
-        method: 'OPTIONS',
-        headers: {
-          origin: 'http://example.com'
+      node: {
+        req: {
+          method: 'OPTIONS',
+          headers: {
+            origin: 'http://example.com'
+          }
         }
       }
     } as H3Event
@@ -174,10 +182,12 @@ describe('isAllowedOrigin', () => {
 describe('createOriginHeaders', () => {
   it('returns an object whose `Access-Control-Allow-Origin` is `"*"` if `origin` option is not defined, `"*"`', () => {
     const eventMock = {
-      req: {
-        method: 'OPTIONS',
-        headers: {
-          origin: 'http://example.com'
+      node: {
+        req: {
+          method: 'OPTIONS',
+          headers: {
+            origin: 'http://example.com'
+          }
         }
       }
     } as H3Event
@@ -192,9 +202,11 @@ describe('createOriginHeaders', () => {
 
   it('returns an object whose `Access-Control-Allow-Origin` is `"*"` if `origin` header is not defined', () => {
     const eventMock = {
-      req: {
-        method: 'OPTIONS',
-        headers: {}
+      node: {
+        req: {
+          method: 'OPTIONS',
+          headers: {}
+        }
       }
     } as H3Event
     const options: CorsOptions = {}
@@ -204,10 +216,12 @@ describe('createOriginHeaders', () => {
 
   it('returns an object with `Access-Control-Allow-Origin` and `Vary` keys if `origin` option is `"null"`', () => {
     const eventMock = {
-      req: {
-        method: 'OPTIONS',
-        headers: {
-          origin: 'http://example.com'
+      node: {
+        req: {
+          method: 'OPTIONS',
+          headers: {
+            origin: 'http://example.com'
+          }
         }
       }
     } as H3Event
@@ -220,10 +234,12 @@ describe('createOriginHeaders', () => {
 
   it('returns an object with `Access-Control-Allow-Origin` and `Vary` keys if `origin` option and `Origin` header matches', () => {
     const eventMock = {
-      req: {
-        method: 'OPTIONS',
-        headers: {
-          origin: 'http://example.com'
+      node: {
+        req: {
+          method: 'OPTIONS',
+          headers: {
+            origin: 'http://example.com'
+          }
         }
       }
     } as H3Event
@@ -286,10 +302,12 @@ describe('createCredentialsHeaders', () => {
 describe('createAllowHeaderHeaders', () => {
   it('returns an object with `Access-Control-Allow-Headers` and `Vary` keys according to `Access-Control-Request-Headers` header if `allowHeaders` option is not defined, `"*"`, or an empty array', () => {
     const eventMock = {
-      req: {
-        method: 'OPTIONS',
-        headers: {
-          'access-control-request-headers': 'CUSTOM-HEADER'
+      node: {
+        req: {
+          method: 'OPTIONS',
+          headers: {
+            'access-control-request-headers': 'CUSTOM-HEADER'
+          }
         }
       }
     } as H3Event
@@ -308,9 +326,11 @@ describe('createAllowHeaderHeaders', () => {
 
   it('returns an object with `Access-Control-Allow-Headers` and `Vary` keys according to `allowHeaders` option', () => {
     const eventMock = {
-      req: {
-        method: 'OPTIONS',
-        headers: {}
+      node: {
+        req: {
+          method: 'OPTIONS',
+          headers: {}
+        }
       }
     } as H3Event
     const options: CorsOptions = {


### PR DESCRIPTION
- updated `h3` to version `1.01` in peer and dev dependencies
- changed deprecated `event.req` to `event.node.req` in `src/handler.ts`
- fixed mock events in `utils.test.ts` to use the same `event` structure