### PR TITLE
feat: use h3 sendNoContent utility

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -8,10 +8,7 @@ export function defineCorsEventHandler (options: CorsOptions) {
   return defineEventHandler((event) => {
     if (isPreflight(event)) {
       appendCorsPreflightHeaders(event, options)
-
-      event.node.res.statusCode = statusCode
-      event.node.res.setHeader('Content-Length', '0')
-      event.node.res.end()
+      sendNoContent(event, statusCode)
     } else {
       appendCorsActualRequestHeaders(event, options)
     }


### PR DESCRIPTION
This utility has been added in https://github.com/unjs/h3/pull/250, and has slightly improved handling of 204 status codes.

Requires a new release of h3.